### PR TITLE
fix(ci): skip build step for PRs from forks

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -32,6 +32,7 @@ jobs:
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Setup EAS
         uses: expo/expo-github-action@v8
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # ForkからのPRは無視
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
@@ -42,4 +43,5 @@ jobs:
       - name: Run test
         run: pnpm jest
       - name: build
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: eas build --platform android --local --non-interactive

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -42,6 +42,6 @@ jobs:
         run: pnpm biome
       - name: Run test
         run: pnpm jest
-      - name: build
+      - name: Build
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: eas build --platform android --local --non-interactive


### PR DESCRIPTION
## Related Issue(s)

Close #7 

## Changes

- ForkからのPRではビルドをスキップする。
  - Dependabotを含むForkからのPRでは、シークレットへのアクセス権がないため、`eas build`が失敗する。パブリックリポジトリである以上、安全性を保ったまま回避するのは現状困難だと感じるためスキップする。

## Note

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
https://qiita.com/SUZUKI_Masaya/items/afe1d43a7343fa3c06f0
